### PR TITLE
Update KubeVirt image builds to create retained standalone DataVolumes

### DIFF
--- a/builderdash/kubevirt_operations.py
+++ b/builderdash/kubevirt_operations.py
@@ -15,21 +15,39 @@ DATAVOLUME_PLURAL = "datavolumes"
 _UNSET_STORAGE_CLASS_VALUES = {"", "none", "null"}
 
 
-def normalize_kubevirt_storage_class_name(value):
+def normalize_k8s_storage_class(value):
     if value is None:
         return None
 
-    storage_class_name = str(value).strip()
-    if storage_class_name.lower() in _UNSET_STORAGE_CLASS_VALUES:
+    storage_class = str(value).strip()
+    if storage_class.lower() in _UNSET_STORAGE_CLASS_VALUES:
         return None
 
-    return storage_class_name
+    return storage_class
 
 
-def get_build_kubevirt_storage_class_name(my_build):
-    return normalize_kubevirt_storage_class_name(
+def get_build_k8s_storage_class(my_build):
+    storage_class = normalize_k8s_storage_class(
+        getattr(my_build, "k8s_storage_class", None)
+    )
+    legacy_storage_class = normalize_k8s_storage_class(
         getattr(my_build, "kubevirt_storage_class_name", None)
     )
+
+    if storage_class and legacy_storage_class and storage_class != legacy_storage_class:
+        raise ValueError(
+            "Builderdash KubeVirt config defines both k8s_storage_class and legacy "
+            f"kubevirt_storage_class_name with different values: {storage_class!r} != {legacy_storage_class!r}"
+        )
+
+    storage_class = storage_class or legacy_storage_class
+    if storage_class is None:
+        raise ValueError(
+            "KubeVirt image builds require k8s_storage_class in the builderdash config. "
+            "Set it to a StorageClass that exists on the target Kubernetes cluster."
+        )
+
+    return storage_class
 
 
 vm_template = dedent('''\
@@ -124,9 +142,7 @@ def generate_data_volume_manifest(my_build):
         }
     }
 
-    storage_class_name = get_build_kubevirt_storage_class_name(my_build)
-    if storage_class_name is not None:
-        pvc_spec["storageClassName"] = storage_class_name
+    pvc_spec["storageClassName"] = get_build_k8s_storage_class(my_build)
 
     return {
         "apiVersion": f"{CDI_GROUP}/{CDI_VERSION}",

--- a/builderdash/kubevirt_operations.py
+++ b/builderdash/kubevirt_operations.py
@@ -10,6 +10,36 @@ from kubernetes.client.rest import ApiException
 
 logger = logging.getLogger(__name__)
 
+_UNSET_STORAGE_CLASS_VALUES = {"", "none", "null"}
+
+
+def normalize_kubevirt_storage_class_name(value):
+    if value is None:
+        return None
+
+    storage_class_name = str(value).strip()
+    if storage_class_name.lower() in _UNSET_STORAGE_CLASS_VALUES:
+        return None
+
+    return storage_class_name
+
+
+def get_build_kubevirt_storage_class_name(my_build):
+    return normalize_kubevirt_storage_class_name(
+        getattr(my_build, "kubevirt_storage_class_name", None)
+    )
+
+
+def get_pv_storage_class_name(client_core_v1_api, pv_name):
+    pv = client_core_v1_api.read_persistent_volume(pv_name)
+    return pv.spec.storage_class_name
+
+
+def render_pvc_storage_class(storage_class_name):
+    if storage_class_name is None:
+        return ''
+    return f"storageClassName: {storage_class_name}"
+
 vm_template = dedent('''\
     apiVersion: kubevirt.io/v1
     kind: VirtualMachine
@@ -80,11 +110,7 @@ def generate_vm_template_substitution_dictionary(my_build):
     kubevirt_public_key_openssh = f.read()
     f.close()
 
-    kubevirt_storage_class_name = getattr(my_build, "kubevirt_storage_class_name", None)
-    if kubevirt_storage_class_name is not None:
-        pvc_storage_class = f"storageClassName: {kubevirt_storage_class_name}"
-    else:
-        pvc_storage_class = ''
+    pvc_storage_class = render_pvc_storage_class(get_build_kubevirt_storage_class_name(my_build))
 
     return {
         'name': my_build.instancename,
@@ -172,7 +198,16 @@ def get_pv_name_from_pvc(client_core_v1_api, namespace, pvc_name):
 
 
 def patch_pv_to_retain(client_core_v1_api, pv_name):
-    # Define the patch to set the PV reclaim policy to Retain
+    try:
+        pv = client_core_v1_api.read_persistent_volume(pv_name)
+    except ApiException as e:
+        logging.error(f"Exception when reading PV '{pv_name}' before retain patch: {e}")
+        raise
+
+    if pv.spec.persistent_volume_reclaim_policy == "Retain":
+        logging.info(f"PV '{pv_name}' already has reclaim policy Retain; skipping patch.")
+        return
+
     pv_patch = {
         "spec": {
             "persistentVolumeReclaimPolicy": "Retain"
@@ -249,8 +284,14 @@ def create_pvc_for_retained_pv(my_build, pv_name):
         }
     }
 
-    kubevirt_storage_class_name = getattr(my_build, "kubevirt_storage_class_name", None)
-    if kubevirt_storage_class_name is not None:
+    kubevirt_storage_class_name = get_build_kubevirt_storage_class_name(my_build)
+    if kubevirt_storage_class_name is None:
+        pv_storage_class_name = get_pv_storage_class_name(my_build.k8s_client_core_v1_api, pv_name)
+        if pv_storage_class_name is None:
+            pvc_manifest['spec']['storageClassName'] = ''
+        else:
+            pvc_manifest['spec']['storageClassName'] = pv_storage_class_name
+    else:
         pvc_manifest['spec']['storageClassName'] = kubevirt_storage_class_name
 
     try:

--- a/builderdash/kubevirt_operations.py
+++ b/builderdash/kubevirt_operations.py
@@ -1,14 +1,16 @@
-import json
 import logging
 import os
 import time
 from textwrap import dedent
 
-import yaml
 from kubernetes import client as client
 from kubernetes.client.rest import ApiException
 
 logger = logging.getLogger(__name__)
+
+CDI_GROUP = "cdi.kubevirt.io"
+CDI_VERSION = "v1beta1"
+DATAVOLUME_PLURAL = "datavolumes"
 
 _UNSET_STORAGE_CLASS_VALUES = {"", "none", "null"}
 
@@ -29,16 +31,6 @@ def get_build_kubevirt_storage_class_name(my_build):
         getattr(my_build, "kubevirt_storage_class_name", None)
     )
 
-
-def get_pv_storage_class_name(client_core_v1_api, pv_name):
-    pv = client_core_v1_api.read_persistent_volume(pv_name)
-    return pv.spec.storage_class_name
-
-
-def render_pvc_storage_class(storage_class_name):
-    if storage_class_name is None:
-        return ''
-    return f"storageClassName: {storage_class_name}"
 
 vm_template = dedent('''\
     apiVersion: kubevirt.io/v1
@@ -88,19 +80,7 @@ vm_template = dedent('''\
                       - {public_key_openssh}
           - name: {root_disk_name}
             dataVolume:
-              name: {pvc_name}
-      dataVolumeTemplates:
-      - metadata:
-          name: {pvc_name}
-        spec:
-          pvc:
-            {pvc_storage_class}
-            accessModes:
-            - {pvc_access_mode}
-            resources:
-              requests:
-                storage: {pvc_storage_capacity}
-          source: {data_volume_source}''')
+              name: {pvc_name}''')
 
 
 def generate_vm_template_substitution_dictionary(my_build):
@@ -109,8 +89,6 @@ def generate_vm_template_substitution_dictionary(my_build):
     f = open(os.path.expanduser(my_build.pubkeypath), 'r')
     kubevirt_public_key_openssh = f.read()
     f.close()
-
-    pvc_storage_class = render_pvc_storage_class(get_build_kubevirt_storage_class_name(my_build))
 
     return {
         'name': my_build.instancename,
@@ -124,7 +102,6 @@ def generate_vm_template_substitution_dictionary(my_build):
         'ssh_user': str(my_build.sshkeyuser),
         'public_key_openssh': kubevirt_public_key_openssh,
         'pvc_name': my_build.instancename,
-        'pvc_storage_class': pvc_storage_class,
         'pvc_access_mode': 'ReadWriteOnce',
         'pvc_storage_capacity': disksize,
         'data_volume_source': my_build.sourceimage,
@@ -134,6 +111,51 @@ def generate_vm_template_substitution_dictionary(my_build):
 
 def generate_rendered_vm_yaml_manifest(my_build):
     return vm_template.format(**generate_vm_template_substitution_dictionary(my_build))
+
+
+def generate_data_volume_manifest(my_build):
+    d = generate_vm_template_substitution_dictionary(my_build)
+    pvc_spec = {
+        "accessModes": [d['pvc_access_mode']],
+        "resources": {
+            "requests": {
+                "storage": d['pvc_storage_capacity']
+            }
+        }
+    }
+
+    storage_class_name = get_build_kubevirt_storage_class_name(my_build)
+    if storage_class_name is not None:
+        pvc_spec["storageClassName"] = storage_class_name
+
+    return {
+        "apiVersion": f"{CDI_GROUP}/{CDI_VERSION}",
+        "kind": "DataVolume",
+        "metadata": {
+            "name": d['pvc_name'],
+            "namespace": d['namespace'],
+        },
+        "spec": {
+            "pvc": pvc_spec,
+            "source": d['data_volume_source'],
+        }
+    }
+
+
+def create_data_volume(custom_objects_api, namespace, manifest):
+    try:
+        api_response = custom_objects_api.create_namespaced_custom_object(
+            group=CDI_GROUP,
+            version=CDI_VERSION,
+            namespace=namespace,
+            plural=DATAVOLUME_PLURAL,
+            body=manifest
+        )
+        logging.info('Standalone DataVolume created successfully')
+        return api_response
+    except ApiException as e:
+        logging.error(f"Exception when creating standalone DataVolume: {e}")
+        return None
 
 
 def create_vm(custom_objects_api, namespace, manifest):
@@ -185,16 +207,12 @@ def get_vmi(custom_objects_api, namespace, vmi_name):
         return None
 
 
-def get_pv_name_from_pvc(client_core_v1_api, namespace, pvc_name):
-    # Retrieve the PVC object from the specified namespace
+def get_pvc(client_core_v1_api, namespace, pvc_name):
     try:
-        pvc = client_core_v1_api.read_namespaced_persistent_volume_claim(name=pvc_name, namespace=namespace)
+        return client_core_v1_api.read_namespaced_persistent_volume_claim(name=pvc_name, namespace=namespace)
     except ApiException as e:
         logging.error(f"Exception when reading namespaced PVC '{pvc_name}' from namespace '{namespace}': {e}")
         raise
-
-    # Return the name of the PV bound to this PVC
-    return pvc.spec.volume_name
 
 
 def patch_pv_to_retain(client_core_v1_api, pv_name):
@@ -221,124 +239,27 @@ def patch_pv_to_retain(client_core_v1_api, pv_name):
         raise
 
 
-def patch_pv_to_nullify_claim_ref(client_core_v1_api, pv_name):
-    # Define the patch to set the claimRef to null (Unbind the PV)
-    pv_patch = {
-        "spec": {
-            "claimRef": None
-        }
-    }
-    try:
-        client_core_v1_api.patch_persistent_volume(pv_name, pv_patch)
-        logging.info(f"Successfully patched PV '{pv_name}' to set the claimRef to null.")
-    except ApiException as e:
-        logging.error(f"Exception when patching PV '{pv_name}' to set the claimRef to null: {e}")
-        raise
-
-
-def wait_for_pvc_to_be_deleted(client_core_v1_api, namespace, pvc_name, timeout, interval):
-    logging.info(f"Waiting for PVC '{pvc_name}' to be deleted...")
+def wait_for_pvc_bound(client_core_v1_api, namespace, pvc_name, timeout, interval):
+    logging.info(f"Waiting for PVC '{pvc_name}' in namespace '{namespace}' to bind...")
     start_time = time.time()
     while time.time() - start_time < timeout:
         try:
-            client_core_v1_api.read_namespaced_persistent_volume_claim(pvc_name, namespace)
-            logging.info(f"PVC '{pvc_name}' still exists, waiting...")
-            time.sleep(interval)  # Wait and retry
+            pvc = client_core_v1_api.read_namespaced_persistent_volume_claim(pvc_name, namespace)
         except ApiException as e:
             if e.status == 404:
-                logging.info(f"PVC '{pvc_name}' has been deleted.")
-                return True
+                logging.info(f"PVC '{pvc_name}' does not exist yet, waiting...")
             else:
                 raise
-    logging.error("Timeout waiting for kubevirt VMI to become ready")
-    return False
-
-
-def create_pvc_for_retained_pv(my_build, pv_name):
-    """
-     This function creates a new PVC to replace the PVC that was deleted when the VM was deleted.
-     This function is intended to be executed after the VM, that was associated with this PVC, is deleted.
-     The VM, its previous PVC, and its new PVC all share the same name -- by convention.
-    """
-
-    d = generate_vm_template_substitution_dictionary(my_build)
-
-    # naming PVC after VM name
-    pvc_name = d['name']
-
-    pvc_manifest = {
-        "apiVersion": "v1",
-        "kind": "PersistentVolumeClaim",
-        "metadata": {
-            "name": pvc_name,
-            "namespace": d['namespace']
-        },
-        "spec": {
-            "accessModes": [d['pvc_access_mode']],
-            "resources": {
-                "requests": {
-                    "storage": d['pvc_storage_capacity']
-                }
-            },
-            "volumeName": pv_name
-        }
-    }
-
-    kubevirt_storage_class_name = get_build_kubevirt_storage_class_name(my_build)
-    if kubevirt_storage_class_name is None:
-        pv_storage_class_name = get_pv_storage_class_name(my_build.k8s_client_core_v1_api, pv_name)
-        if pv_storage_class_name is None:
-            pvc_manifest['spec']['storageClassName'] = ''
         else:
-            pvc_manifest['spec']['storageClassName'] = pv_storage_class_name
-    else:
-        pvc_manifest['spec']['storageClassName'] = kubevirt_storage_class_name
-
-    try:
-        response = my_build.k8s_client_core_v1_api.create_namespaced_persistent_volume_claim(
-            d['namespace'],
-            pvc_manifest
-        )
-    except client.exceptions.ApiException as e:
-        logging.error(f"Exception when creating PVC: {e}")
-        raise
-    else:
-        logging.info(f"PVC '{pvc_name}' created successfully.")
-        return response
-
-
-def wait_for_pvc_deletion_then_recreate(my_build, timeout=600, interval=1):
-    """
-    Re-create the PVC after the VM has been deleted. The first PVC associated with the VM must be deleted by the time
-    create_pvc_for_retained_pv is called or else it will likely raise an exception.
-
-    Background:
-    For builderdash, the lifecycle of the PVC should be managed separately from the kubevirt VM.
-
-    When a kubevirt VM is created with a dataVolumeTemplates section, a PVC is created and its lifecycle is bound to
-    that of the VM; however, we want the PVC to exist beyond the deletion of the VM so that it may be reused later on
-    without additional steps being required of the user of the desired build output image.
-
-    To support that, another PVC is created after the VM and its original PVC have been deleted. The new PVC is bound to
-    the original PV that was retained.
-    """
-    pvc_name = my_build.instancename
-    try:
-        pv_name = get_pv_name_from_pvc(my_build.k8s_client_core_v1_api, my_build.k8s_namespace, pvc_name)
-    except Exception:
-        return False
-
-    ret = wait_for_pvc_to_be_deleted(my_build.k8s_client_core_v1_api, my_build.k8s_namespace, pvc_name, timeout,
-                                     interval)
-    if ret:
-        try:
-            patch_pv_to_nullify_claim_ref(my_build.k8s_client_core_v1_api, pv_name)
-            create_pvc_for_retained_pv(my_build, pv_name)
-        except Exception:
-            return False
-        else:
-            return True
-    return False
+            phase = pvc.status.phase
+            volume_name = pvc.spec.volume_name
+            if phase == "Bound" and volume_name:
+                logging.info(f"PVC '{pvc_name}' is Bound to PV '{volume_name}'.")
+                return pvc
+            logging.info(f"PVC '{pvc_name}' phase is '{phase}', waiting...")
+        time.sleep(interval)
+    logging.error(f"Timeout waiting for PVC '{pvc_name}' to bind")
+    return None
 
 
 def wait_for_vmi_running(custom_objects_api, namespace, vmi_name, timeout, interval):
@@ -437,40 +358,62 @@ def wait_for_vmi_ip(custom_objects_api, namespace, vmi_name, timeout, interval):
     return None
 
 
-def set_retainment_of_root_volume(
-        client_core_v1_api,
-        k8s_namespace,
-        vm_name,
-):
-    try:
-        pvc_name = vm_name
-        pv_name = get_pv_name_from_pvc(client_core_v1_api, k8s_namespace, pvc_name)
-        patch_pv_to_retain(client_core_v1_api, pv_name)
-    except ApiException:
-        raise
-    except Exception as e:
-        logging.error(f"Unexpected exception when trying to get PV name and retain PV: {e}")
-        raise
-
-
 def create_vm_and_wait_for_ip(
         client_core_v1_api,
         custom_objects_api,
         k8s_namespace,
         vm_name,
         manifest,
+        data_volume_manifest,
         timeout=600,          # total budget for running+IP
         interval=10,
         retain_root_volume=True,
 ):
     start_time = time.time()
 
+    data_volume = create_data_volume(custom_objects_api, k8s_namespace, data_volume_manifest)
+    if not data_volume:
+        logging.error('failed to create standalone DataVolume')
+        return None
+
     vm = create_vm(custom_objects_api, k8s_namespace, manifest)
     if not vm:
         logging.error('failed create kubevirt VM')
         return None
 
-    # ---- 1) Wait for VMI to be Running ----
+    # ---- 1) Wait for the standalone DataVolume's PVC to bind ----
+    remaining = timeout - (time.time() - start_time)
+    logging.info(f"[builderdash] Remaining time before wait_for_pvc_bound: {remaining:.1f}s")
+
+    if remaining <= 0:
+        logging.error("Timeout expired before waiting for root PVC to bind")
+        return None
+
+    pvc = wait_for_pvc_bound(
+        client_core_v1_api,
+        k8s_namespace,
+        vm_name,
+        timeout=remaining,
+        interval=interval,
+    )
+    if not pvc:
+        logging.error('failed to get bound root PVC')
+        return None
+
+    # ---- 2) Retain root volume ----
+    if retain_root_volume:
+        try:
+            patch_pv_to_retain(client_core_v1_api, pvc.spec.volume_name)
+        except Exception:
+            logging.exception(
+                "Failed to set retainment on root volume for VM %s; deleting VM", vm_name
+            )
+            delete_vm(custom_objects_api, k8s_namespace, vm_name)
+            return None
+    else:
+        logging.warning("retain_root_volume is False; root volume will be deleted if its PVC is deleted")
+
+    # ---- 3) Wait for VMI to be Running ----
     remaining = timeout - (time.time() - start_time)
     logging.info(f"[builderdash] Remaining time before wait_for_vmi_running: {remaining:.1f}s")
 
@@ -489,20 +432,7 @@ def create_vm_and_wait_for_ip(
         logging.error('failed to get VMI data (never reached Running)')
         return None
 
-    # ---- 2) Retain root volume ----
-    if retain_root_volume:
-        try:
-            set_retainment_of_root_volume(client_core_v1_api, k8s_namespace, vm_name)
-        except Exception:
-            logging.exception(
-                "Failed to set retainment on root volume for VM %s; deleting VM", vm_name
-            )
-            delete_vm(custom_objects_api, k8s_namespace, vm_name)
-            return None
-    else:
-        logging.warning("retain_root_volume is False; root volume will be deleted with VM")
-
-    # ---- 3) Wait for VMI IP ----
+    # ---- 4) Wait for VMI IP ----
     remaining = timeout - (time.time() - start_time)
     logging.info(f"[builderdash] Remaining time before wait_for_vmi_ip: {remaining:.1f}s")
 

--- a/builderdash/main.py
+++ b/builderdash/main.py
@@ -30,9 +30,10 @@ import kubernetes
 from builderdash.kubevirt_operations import (
     create_vm_and_wait_for_ip,
     delete_vm,
+    generate_data_volume_manifest,
     generate_rendered_vm_yaml_manifest,
+    get_pvc,
     stop_vmi,
-    wait_for_pvc_deletion_then_recreate,
 )
 from builderdash.ssher import SSHConnection, load_proxy_conf_file
 
@@ -586,8 +587,13 @@ def kubevirt_instance(my_build, timeout=3600, interval=10):
     my_build.instanceId = None
 
     rendered_manifest = generate_rendered_vm_yaml_manifest(my_build)
+    data_volume_manifest = generate_data_volume_manifest(my_build)
 
     logging.info(f'Rendered kubevirt VM instance yaml manifest:\n# BEGIN\n{rendered_manifest}\n# END')
+    logging.info(
+        "Rendered standalone kubevirt DataVolume yaml manifest:\n# BEGIN\n%s# END",
+        yaml.safe_dump(data_volume_manifest, sort_keys=False)
+    )
 
     try:
         vm_manifest = yaml.safe_load(rendered_manifest)
@@ -603,6 +609,7 @@ def kubevirt_instance(my_build, timeout=3600, interval=10):
         my_build.k8s_namespace,
         my_build.instancename,
         vm_manifest,
+        data_volume_manifest,
         timeout=timeout,
         interval=interval
     )
@@ -911,12 +918,27 @@ def saveImage(slist, myBuild):
     elif myBuild.env_provider == EnvProvider.K8S_VM:
         logging.info('Saving kubevirt image -- really just recording a reference to the build instance persistent volume claim name and namespace.')
         pvc_name = myBuild.instancename
+        try:
+            pvc = get_pvc(myBuild.k8s_client_core_v1_api, myBuild.k8s_namespace, pvc_name)
+        except Exception:
+            logging.exception(
+                "Failed to read KubeVirt image PVC '%s/%s' before recording image metadata.",
+                myBuild.k8s_namespace,
+                pvc_name,
+            )
+            sys.exit(1)
+
         savedImage = {
             "pvc": {
                 "name": pvc_name,
                 "namespace": myBuild.k8s_namespace
             }
         }
+        if pvc.spec.storage_class_name is not None:
+            savedImage["pvc"]["storageClassName"] = pvc.spec.storage_class_name
+        if pvc.spec.volume_name is not None:
+            savedImage["pvc"]["volumeName"] = pvc.spec.volume_name
+
         logging.info('kubevirt pvc: ' + json.dumps(savedImage))
     # TODO: even though savedImage is returned is it ever really used?
     return(savedImage)
@@ -1125,12 +1147,11 @@ def deleteInstance(delList, myBuild):
     elif myBuild.env_provider == EnvProvider.K8S_VM:
         logging.info(f"Deleting kubevirt instance: {myBuild.instancename}")
         delete_vm(myBuild.k8s_custom_objects_api, myBuild.k8s_namespace, myBuild.instancename)
-        ret = wait_for_pvc_deletion_then_recreate(myBuild)
-        if ret:
-            logging.info("PVC successfully re-created following deletion of VM and its original PVC.")
-        else:
-            logging.error("PVC failed to be re-created following deletion of VM and its original PVC.")
-            sys.exit(1)
+        logging.info(
+            "KubeVirt VM deleted. Standalone DataVolume/PVC '%s/%s' remains as the saved image artifact.",
+            myBuild.k8s_namespace,
+            myBuild.instancename,
+        )
     else:
         logging.error("build has invalid env_provider")
 

--- a/builderdash/main.py
+++ b/builderdash/main.py
@@ -587,7 +587,11 @@ def kubevirt_instance(my_build, timeout=3600, interval=10):
     my_build.instanceId = None
 
     rendered_manifest = generate_rendered_vm_yaml_manifest(my_build)
-    data_volume_manifest = generate_data_volume_manifest(my_build)
+    try:
+        data_volume_manifest = generate_data_volume_manifest(my_build)
+    except ValueError as e:
+        logging.error(str(e))
+        sys.exit(1)
 
     logging.info(f'Rendered kubevirt VM instance yaml manifest:\n# BEGIN\n{rendered_manifest}\n# END')
     logging.info(

--- a/builderdash/main.py
+++ b/builderdash/main.py
@@ -64,6 +64,17 @@ class EnvProvider(str, Enum):
         ]
 
 
+def normalize_kubernetes_client_bearer_token():
+    kube_config = kubernetes.client.Configuration.get_default_copy()
+    if 'authorization' not in kube_config.api_key or 'BearerToken' in kube_config.api_key:
+        return False
+
+    # kubernetes 36 loads kubeconfig tokens as "authorization", while generated APIs expect "BearerToken".
+    kube_config.api_key['BearerToken'] = kube_config.api_key['authorization']
+    kubernetes.client.Configuration.set_default(kube_config)
+    return True
+
+
 class Build:
     tagList = None
     env_provider = None
@@ -124,6 +135,7 @@ class Build:
             context=getattr(self, 'k8s_kubeconfig_context', None),
             persist_config=False
         )
+        normalize_kubernetes_client_bearer_token()
 
         contexts, current_context = kubernetes.config.list_kube_config_contexts(config_file)
 


### PR DESCRIPTION
## Summary

This PR updates Builderdash’s KubeVirt image-build lifecycle so build root disks are created as standalone CDI `DataVolume`/PVC artifacts instead of VM-owned `dataVolumeTemplates`.

That lets Builderdash keep the completed golden image PVC bound after the build VM is deleted, which is the shape Eureka needs for fast CDI CSI cloning from retained `balanced-csi` source volumes.

## What Changed

- Creates the KubeVirt build root disk as a standalone CDI `DataVolume` before creating the build VM.
- Removes VM-owned `dataVolumeTemplates` from the generated KubeVirt VM manifest.
- Waits for the standalone DataVolume-created PVC to bind before continuing VM readiness checks.
- Patches the bound PV reclaim policy to `Retain` so the golden image disk survives PVC/cluster lifecycle operations.
- Deletes only the build VM at the end of the build, leaving the standalone DataVolume/PVC as the saved image artifact.
- Removes the older PVC resurrection path that waited for VM-owned PVC deletion, cleared `claimRef`, and recreated a PVC.
- Requires KubeVirt builds to provide `k8s_storage_class`, while keeping `kubevirt_storage_class_name` as a compatibility alias with conflict detection.
- Records richer saved-image metadata, including PVC `storageClassName` and `volumeName`.
- Normalizes Kubernetes client bearer token handling so service-account kubeconfigs work with Kubernetes Python client generated APIs.

## Why

The previous Builderdash KubeVirt lifecycle created the root disk through VM `dataVolumeTemplates`, which tied the PVC lifecycle to the VM. Deleting the build VM also deleted the VM-owned PVC, forcing Builderdash to repair the retained PV by nulling `claimRef` and recreating the PVC.

That lifecycle is fragile and works against the desired Eureka image model. For CDI CSI cloning, golden image PVCs should remain stable, bound source PVCs. This PR makes the golden image disk an explicit standalone artifact and leaves it in place after the VM build completes.

For the GCP kOps KubeVirt dev cluster, the intended image build contract is:

- Builderdash golden image PVCs use `k8s_storage_class: balanced-csi`
- The golden image PV is patched to `Retain`
- Eureka runtime VM target PVCs also use `balanced-csi`
- CDI can use CSI cloning because source and target PVCs use the same StorageClass

## Validation

- `git diff --check origin/master...HEAD` passed.
- Python AST parse passed for:
  - `builderdash/kubevirt_operations.py`
  - `builderdash/main.py`
- Local import smoke check passed using the installed Builderdash uv tool environment.
- Manifest smoke check passed:
  - generated standalone DataVolume includes `storageClassName: balanced-csi`
  - generated VM manifest no longer includes `dataVolumeTemplates`
  - VM root volume references the standalone DataVolume
  - missing `k8s_storage_class` raises a clear error
  - conflicting `k8s_storage_class` and legacy `kubevirt_storage_class_name` raises a clear error

## Notes

This branch is the Builderdash side of the KubeVirt CDI clone work (see [Eureka #218](https://github.com/omnibond/eureka/pull/218)). It prepares golden image PVCs in the form Eureka needs for efficient clone-based VM startup while preserving retained-disk behavior for image artifacts.
